### PR TITLE
Export cassandra configuration in sample app

### DIFF
--- a/sample-config/cassandra-myservice/runtime-config.sh
+++ b/sample-config/cassandra-myservice/runtime-config.sh
@@ -1,3 +1,3 @@
 # Demonstrate providing an entirely new configuration directory
 CURRENT_PATH=`dirname "$0"`
-export $CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf
+export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf


### PR DESCRIPTION
The https://github.com/huntc/conductr-cassandra/blob/master/sample-config/cassandra-myservice/runtime-config.sh#L3 in the sample config contains an invalid `export` command.

As a result, the custom Cassandra configuration inside the `cassandra-conf` directory is not getting correctly included:

```
4036200951222982399/463d43f142f64d464b50b38a7790fc41635d988f00188a9311b0634cd3d7211d/cassandra-configuration/runtime-config.sh: line 3: export: `=/Users/mj/.conductr/images/tmp/conductr-agent/192.168.10.1/bundles/4f71ca2fc8760ddabadfd8bdcdfbfbcc-463d43f142f64d464b50b38a7790fc41/execution-0-4036200951222982399/cassandra-conf': not a valid identifier
```

This PR is fixing the `export` command.